### PR TITLE
Make clang-format command work

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM debian:stretch
 
 RUN apt-get update && \
-    apt-get install --no-install-recommends -y bzip2 clang-format-3.9 clang-tidy-3.9 \
+    apt-get install -y bzip2 clang-format-3.9 clang-tidy-3.9 \
         cloc cmake cppcheck curl doxygen gcc git graphviz g++ libpcap-dev lcov make \
         mpich python-dev python3 python3-pip valgrind autoconf automake libtool perl && \
     apt-get autoremove -y && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM debian:stretch
 
 RUN apt-get update && \
-    apt-get install -y bzip2 clang-format-3.9 clang-tidy-3.9 cloc cmake cppcheck curl doxygen gcc git graphviz \
-        g++ libpcap-dev lcov make mpich python-dev python3 python3-pip valgrind autoconf automake libtool perl && \
+    apt-get install --no-install-recommends -y bzip2 clang-format-3.9 clang-tidy-3.9 \
+        cloc cmake cppcheck curl doxygen gcc git graphviz g++ libpcap-dev lcov make \
+        mpich python-dev python3 python3-pip valgrind autoconf automake libtool perl && \
     apt-get autoremove -y && \
-    apt-get clean
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN pip3 install --force-reinstall pip==9.0.3 && \
     pip3 install conan==1.3.3 coverage==4.4.2 flake8==3.5.0 gcovr==3.4 && \
@@ -18,6 +20,9 @@ RUN mkdir $CONAN_USER_HOME && \
 COPY files/registry.txt $CONAN_USER_HOME/.conan/
 
 COPY files/default_profile $CONAN_USER_HOME/.conan/profiles/default
+
+RUN ln -s /usr/lib/llvm-3.9/bin/clang-format /usr/bin/clang-format
+RUN ln -s /usr/lib/llvm-3.9/bin/clang-tidy /usr/bin/clang-tidy
 
 RUN conan install cmake_installer/3.10.0@conan/stable
 


### PR DESCRIPTION
Closes #2

Linked `clang-format` and `clang-tidy` executables in `/usr/bin/`.

Also used  `rm -rf /var/lib/apt/lists/*` in the `apt install` layer which may reduce image size slightly.

After building, I tested with:
```
docker run -t <image_tag> clang-format --version
```